### PR TITLE
Let the user configure the request method for banning

### DIFF
--- a/classes/class.tx_varnish_controller.php
+++ b/classes/class.tx_varnish_controller.php
@@ -83,11 +83,13 @@ class tx_varnish_controller {
 			'Varnish-Ban-TYPO3-Sitename: ' . tx_varnish_GeneralUtility::getSitename()
 		);
 
+		$method = self::$extConf['banRequestMethod'] ? self::$extConf['banRequestMethod'] : "BAN";
+
 		// issue command on every Varnish Server
 		/** @var $varnishHttp tx_varnish_http */
 		$varnishHttp = t3lib_div::makeInstance('tx_varnish_http');
 		foreach(self::$extConf['instanceHostnames'] as $currentHost) {
-			$varnishHttp::addCommand('BAN', $currentHost, $command);
+			$varnishHttp::addCommand($method, $currentHost, $command);
 		}
 
 	}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -4,3 +4,5 @@ instanceHostnames =
 enableDevLog = 0
 # cat=basic/; type=boolean; label=LLL:EXT:varnish/locallang.xml:extconf_alwayssendtypo3headers
 alwaysSendTypo3Headers = 0
+# cat=basic/; type=string; label=LLL:EXT:varnish/locallang.xml:extconf_banRequestMethod
+banRequestMethod = BAN

--- a/locallang.xml
+++ b/locallang.xml
@@ -13,6 +13,7 @@
 			<label index="extconf_instancehostnames">Varnish Servers:By default, the Hostname of your Backend Connection is used to connect to Varnish which is usually fine. If your Varnish Server Hostname is different from your Backend Hostname or you run multiple Varnish Instances add those Hostnames here as a Comma separated List.</label>
 			<label index="extconf_enabledevlog">Debug:Write Debug Messages about Varnish Actions to devLog.</label>
 			<label index="extconf_alwayssendtypo3headers">Always send TYPO3 Headers:Forces TYPO3 to always send TYPO3 cache specific headers. Is also set on the fly according [SYS][reverseProxyIP] and therefore usually not required.</label>
+			<label index="extconf_banRequestMethod">HTTP request method for banning:By default the BAN request is sent to varnish to clear the cache. This is a nonstandard method and may be blocked by your network. In that case, choose another one (PURGE is standardised).</label>
 		</languageKey>
 		<languageKey index="de" type="array">
 			<label index="be_clear_cache_menu">Varnish Cache leeren</label>


### PR DESCRIPTION
Our firewall blocks nonstandard "BAN" request, so we need to use another method.
This patch lets the user configure the extension to use another HTTP method for banning.
I think this is a feature more people might need!
-Chris