### PR TITLE
Revert "TYPO3 6.2 Compatibility: Use EXT: in hooks, ext_autoload does no...

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -30,13 +30,13 @@ switch(TYPO3_MODE) {
 		t3lib_extMgm::addTypoScriptSetup('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:varnish/static/setup.txt">');
 
 		// Hooks
-		$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-output'][] = 'EXT:varnish/classes/Hooks/class.tx_varnish_hooks_tslib_fe.php:tx_varnish_hooks_tslib_fe->sendHeader';
+		$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-output'][] = 'tx_varnish_hooks_tslib_fe->sendHeader';
 		break;
 	case 'BE':
 		// Hooks
-		$TYPO3_CONF_VARS['BE']['AJAX']['tx_varnish::banAll'] = 'EXT:varnish/classes/Hooks/class.tx_varnish_hooks_ajax.php:tx_varnish_hooks_ajax->banAll';
-		$TYPO3_CONF_VARS['SC_OPTIONS']['additionalBackendItems']['cacheActions'][] = 'EXT:varnish/classes/Hooks/class.tx_varnish_hooks_clearcachemenu.php:tx_varnish_hooks_clearcachemenu';
-		$TYPO3_CONF_VARS['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = 'EXT:varnish/classes/Hooks/class.tx_varnish_hooks_tcemain.php:tx_varnish_hooks_tcemain->clearCachePostProc';
+		$TYPO3_CONF_VARS['BE']['AJAX']['tx_varnish::banAll'] = 'tx_varnish_hooks_ajax->banAll';
+		$TYPO3_CONF_VARS['SC_OPTIONS']['additionalBackendItems']['cacheActions'][] = 'tx_varnish_hooks_clearcachemenu';
+		$TYPO3_CONF_VARS['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = 'tx_varnish_hooks_tcemain->clearCachePostProc';
 
 		break;
 }


### PR DESCRIPTION
...t work anymore"

Reverted due to "Fatal error:  Class 'tx_varnish_controller' not found" in TYPO3 6.2 (autoloader still seems to work fine)

This reverts commit af56fd9f0ff27bba5218e453b293b8a9f513d578.

The changes to ```ext_localconf.php``` in **af56fd9f0ff27bba5218e453b293b8a9f513d578** cause a fatal error:

```
Fatal error:  Class 'tx_varnish_controller' not found in /Users/stu/Public/TYPO3/TYPO3/6.2/typo3/sysext/core/Classes/Utility/GeneralUtility.php on line 4365, referer: http://www.my-domain.dev/typo3/backend.php
Stack trace:, referer: http://www.my-domain.dev/typo3/backend.php
  1. {main}() /Users/stu/Public/TYPO3/TYPO3/6.2/typo3/tce_db.php:0, referer: http://www.my-domain.dev/typo3/backend.php
  2. TYPO3\\CMS\\Backend\\Controller\\SimpleDataHandlerController->main() /Users/stu/Public/TYPO3/TYPO3/6.2/typo3/tce_db.php:30, referer: http://www.my-domain.dev/typo3/backend.php
  3. TYPO3\\CMS\\Core\\DataHandling\\DataHandler->clear_cacheCmd() /Users/stu/Public/TYPO3/TYPO3/6.2/typo3/sysext/backend/Classes/Controller/SimpleDataHandlerController.php:217, referer: http://www.my-domain.dev/typo3/backend.php
  4. TYPO3\\CMS\\Core\\Utility\\GeneralUtility::callUserFunction() /Users/stu/Public/TYPO3/TYPO3/6.2/typo3/sysext/core/Classes/DataHandling/DataHandler.php:7228, referer: http://www.my-domain.dev/typo3/backend.php
  5. call_user_func_array:{/Users/stu/Public/TYPO3/TYPO3/6.2/typo3/sysext/core/Classes/Utility/GeneralUtility.php:4233}() /Users/stu/Public/TYPO3/TYPO3/6.2/typo3/sysext/core/Classes/Utility/GeneralUtility.php:4233, referer: http://www.my-domain.dev/typo3/backend.php
  6. tx_varnish_hooks_tcemain->clearCachePostProc() /Users/stu/Public/TYPO3/TYPO3/6.2/typo3/sysext/core/Classes/Utility/GeneralUtility.php:4233, referer: http://www.my-domain.dev/typo3/backend.php
  7. TYPO3\\CMS\\Core\\Utility\\GeneralUtility::makeInstance() /Users/stu/Sites/my-domain.dev/htdocs/typo3conf/ext/varnish/classes/Hooks/class.tx_varnish_hooks_tcemain.php:44, referer: http://www.my-domain.dev/typo3/backend.php
  8. TYPO3\\CMS\\Core\\Utility\\GeneralUtility::instantiateClass() /Users/stu/Public/TYPO3/TYPO3/6.2/typo3/sysext/core/Classes/Utility/GeneralUtility.php:4347, referer: http://www.my-domain.dev/typo3/backend.php
```
