### PR TITLE
[BUGFIX] Use t3lib_extMgm::addTypoScript() for adding TypoScript setup

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -27,7 +27,7 @@ if(!defined('TYPO3_MODE')) die ('Access denied.');
 switch(TYPO3_MODE) {
 	case 'FE':
 		// Typoscript
-		t3lib_extMgm::addTypoScriptSetup('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:varnish/static/setup.txt">');
+		t3lib_extMgm::addTypoScript('varnish', 'setup', '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:varnish/static/setup.txt">', 43);
 
 		// Hooks
 		$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-output'][] = 'EXT:varnish/classes/Hooks/class.tx_varnish_hooks_tslib_fe.php:tx_varnish_hooks_tslib_fe->sendHeader';


### PR DESCRIPTION
When t3lib_extMgm::addTypoScriptSetup() is called, it may happen that the
rowSum has a different value after $TSFE->tmpl->runThroughTemplates() and
after $TSFE->tmpl->generateConfig(). The result is that the page is cached
but not found due to looking for a wrong hash.

This seems to be a bug in t3lib_extMgm::addTypoScriptSetup() which needs
more investigation. It also seems like the function is rarely used so it
may not have been noticed yet.
For now, the workaround is to call t3lib_extMgm::addTypoScript() which
works fine.